### PR TITLE
Separate ground zipper and zipper effects, only apply better one

### DIFF
--- a/src/karts/kart.cpp
+++ b/src/karts/kart.cpp
@@ -2468,6 +2468,9 @@ void Kart::handleZipper(const Material *material, bool play_sound, bool mini_zip
     /** Additional engine force. */
     float engine_force;
 
+	/*MS_INCREASE_ZIPPER or MS_INCREASE_GROUND_ZIPPER*/
+    unsigned int boost_category;
+
     if(material)
     {
         material->getZipperParameter(&max_speed_increase, &duration,
@@ -2482,6 +2485,7 @@ void Kart::handleZipper(const Material *material, bool play_sound, bool mini_zip
             fade_out_time      = m_kart_properties->getZipperFadeOutTime();
         if(engine_force<0)
             engine_force       = m_kart_properties->getZipperForce();
+        boost_category = MaxSpeed::MS_INCREASE_GROUND_ZIPPER;
     }
     else
     {
@@ -2501,11 +2505,12 @@ void Kart::handleZipper(const Material *material, bool play_sound, bool mini_zip
             fade_out_time      = m_kart_properties->getZipperFadeOutTime();
             engine_force       = m_kart_properties->getZipperForce();
         }
+        boost_category = MaxSpeed::MS_INCREASE_ZIPPER;
     }
     // Ignore a zipper that's activated while braking
     if(m_controls.getBrake() || m_speed<0) return;
 
-    m_max_speed->instantSpeedIncrease(MaxSpeed::MS_INCREASE_ZIPPER,
+    m_max_speed->instantSpeedIncrease(boost_category,
                                      max_speed_increase, speed_gain,
                                      engine_force,
                                      stk_config->time2Ticks(duration),

--- a/src/karts/max_speed.cpp
+++ b/src/karts/max_speed.cpp
@@ -448,7 +448,9 @@ void MaxSpeed::update(int ticks)
         m_add_engine_force  += speedup.getEngineForce();
     }
 
-	/*Only apply the engine force and speed from the zipper/ground zipper boost with the higher amount of both*/
+    // Pick the highest applicable speed boost and the highest applicable engine boost, 
+    // which may come from different effects. This approach fixes all possible "fade-out"
+    // issues.
     for(unsigned int i=MS_INCREASE_ZIPPER; i<=MS_INCREASE_GROUND_ZIPPER; i++)
     {
         SpeedIncrease &speedup = m_speed_increase[i];

--- a/src/karts/max_speed.cpp
+++ b/src/karts/max_speed.cpp
@@ -424,6 +424,9 @@ void MaxSpeed::update(int ticks)
     float max_skid_speed = 0.0f;
     float max_skid_engine_force = 0.0f;
 
+    float max_zipper_speed = 0.0f;
+    float max_zipper_engine_force = 0.0f;
+
     for(unsigned int i=MS_DECREASE_MIN; i<MS_DECREASE_MAX; i++)
     {
         SpeedDecrease &slowdown = m_speed_decrease[i];
@@ -444,6 +447,21 @@ void MaxSpeed::update(int ticks)
         m_current_max_speed += speedup.getSpeedIncrease();
         m_add_engine_force  += speedup.getEngineForce();
     }
+
+	/*Only apply the engine force and speed from the zipper/ground zipper boost with the higher amount of both*/
+    for(unsigned int i=MS_INCREASE_ZIPPER; i<=MS_INCREASE_GROUND_ZIPPER; i++)
+    {
+        SpeedIncrease &speedup = m_speed_increase[i];
+        if (speedup.getSpeedIncrease() > max_zipper_speed)
+            max_zipper_speed = speedup.getSpeedIncrease();
+        if (speedup.getEngineForce() > max_zipper_engine_force)
+            max_zipper_engine_force = speedup.getEngineForce();
+
+        m_current_max_speed -= speedup.getSpeedIncrease();
+        m_add_engine_force  -= speedup.getEngineForce();
+    }
+    m_current_max_speed += max_zipper_speed;
+    m_add_engine_force  += max_zipper_engine_force;
 
     // Prevent the different kinds of skidding speed increases from cumulating
     // We select the highest active max-speed bonus and engine-force bonus,

--- a/src/karts/max_speed.hpp
+++ b/src/karts/max_speed.hpp
@@ -36,6 +36,7 @@ public:
      *  skidding usage, or electro-shield. */
     enum  {MS_INCREASE_MIN,
            MS_INCREASE_ZIPPER = MS_INCREASE_MIN,
+           MS_INCREASE_GROUND_ZIPPER,
            MS_INCREASE_SLIPSTREAM,
            MS_INCREASE_NITRO,
            MS_INCREASE_RUBBER,


### PR DESCRIPTION
## Agreement
```
By creating a pull request in stk-code, you hereby agree to dual-license your contribution as
GNU General Public License version 3 or any later version and
Mozilla Public License version 2 or any later version.

This includes your previous contribution(s) under the same name of contributor.

Keep the above statement in the pull request comment for agreement.

```
This change follows the template of the existing code to preven the effect of skid bonuses from cumulating. With this change, ground zippers do not have any texture slowdown (preserving the intention of track designers). Additionally, now using an item zipper while under the effects of a ground zipper will not cancel the ground zipper effect, and vice versa. The better engine force and max speed increased of the two will be applied for the duration of each corresponding boost, and it will fall back to the "worse" boost engine force / max speed when it times out. This way, using a zipper while under the effects of a ground zipper is not useless as it will in the majority of cases still make you accelerate faster.