### PR TITLE
Revert commit that broke digital bindings to analog axis.

### DIFF
--- a/src/input/device_config.hpp
+++ b/src/input/device_config.hpp
@@ -103,7 +103,8 @@ public:
     virtual bool load(const XMLNode *config);
 
     // ------------------------------------------------------------------------
-    /** Returns true if this device has an analog axis. */
+    /** Returns true if this device has analog axis, so that steering values
+     *  will not be affected by time-full-steer delays. */
     virtual bool isAnalog(Input::InputType type, int id) const { return false;}
     // ------------------------------------------------------------------------
     /** Returns true if this device should desensitize its input at values

--- a/src/input/gamepad_device.cpp
+++ b/src/input/gamepad_device.cpp
@@ -146,6 +146,18 @@ bool GamePadDevice::processAndMapInput(Input::InputType type, const int id,
 {
     if (!m_configuration->isEnabled()) return false;
 
+    // A digital input value is 32767 or -32768 (which then triggers 
+    // time-full-steer to be used to adjust actual steering values.
+    // To prevent this delay for analog gamesticks, make sure that
+    // 32767/-32768 are never used.
+    if(m_configuration->isAnalog(type, id))
+    {
+        if(*value==32767)
+            *value = 32766;
+        else if(*value==-32768)
+            *value = -32767;
+    }
+
     // Desensitizing means to map an input in the range x in [0,1] to
     // x^2. This results in changes close to 0 to have less impact
     // (less sensitive).


### PR DESCRIPTION
This reverts commit dd464af2e6d4c1e17e4ec450c4059c07af124aa7.

Strictly speaking, reverting this commit fixes the issue with no side effects but it is not completely clear why that code did NOT cause this issue in the first place. Other solutions might be worth looking into.

Explained fairly well in https://github.com/Nomagno/stk-code/issues/27
The "edit" section was just because releasing accel makes the kart not consume nitro, nothing to do.
This issue also affects binding look back, brake, or any other digital action to an analog axis That has its resting position as fully negative, and its fully pressed position to fully positive.

Steps to reproduce:
With a controller, bind e.g. "look back" to analog right trigger, or "nitro", whatever really. Once you press it once, it is now (almost) impossible to get the game to stop doing the action. The only way is to get the trigger to be EXACTLY 0 by pressing it exactly halfway, which isn't that hard but is a completely broken way to play.

## Agreement
```
By creating a pull request in stk-code, you hereby agree to dual-license your contribution as
GNU General Public License version 3 or any later version and
Mozilla Public License version 2 or any later version.

This includes your previous contribution(s) under the same name of contributor.

Keep the above statement in the pull request comment for agreement.

```
