### PR TITLE
Fix bad checking of values in setStartupBoost()

### DIFF
--- a/src/karts/kart.cpp
+++ b/src/karts/kart.cpp
@@ -1369,11 +1369,17 @@ void Kart::setStartupBoostFromStartTicks(int ticks)
 void Kart::setStartupBoost(uint8_t boost_level)
 {
     std::vector<float> startup_times = m_kart_properties->getStartupTime();
-    int index = m_kart_properties->getStartupTime().size() - boost_level + 1;
-    assert(index >= 0 && index <= (int)m_kart_properties->getStartupTime().size());
 
-    m_startup_boost = m_kart_properties->getStartupBoost()[index];
-    m_startup_engine_force = m_kart_properties->getStartupEngineForce()[index];
+    if (boost_level >= 2) {
+        int index = m_kart_properties->getStartupTime().size() - boost_level + 1;
+        assert(index >= 0 && index < (int)m_kart_properties->getStartupTime().size());
+        m_startup_boost = m_kart_properties->getStartupBoost()[index];
+        m_startup_engine_force = m_kart_properties->getStartupEngineForce()[index];
+    } else {
+        m_startup_boost = 0;
+        m_startup_engine_force = 0;
+    }
+
     m_startup_boost_level = boost_level;
 }   // setStartupBoost
 


### PR DESCRIPTION
This issue was caused by an oversight in the preconditions of f90c4525977e28996897ea81ba29731c86bcaa7f.
The consequence was that, in online races, if a player didn't press anything during the start sequence, the `boost_level` value of 1, indicating a normal start with no penalties and no boosts, would get sent from the server to the clients. This would then be processed by `Kart::setStartupBoost(uint8_t boost_level)`, which in fact had a wrong assert that treated a boost level of 1 as a valid value, when it instead resulted on an out-of-bounds memory access to the startup boost vectors when fed into the index formula, crashing every single client.
Fixed by adding an alternate scenario for when the boost level is < 2.

## Agreement
```
By creating a pull request in stk-code, you hereby agree to dual-license your contribution as
GNU General Public License version 3 or any later version and
Mozilla Public License version 2 or any later version.

This includes your previous contribution(s) under the same name of contributor.

Keep the above statement in the pull request comment for agreement.
```
